### PR TITLE
Remove 'main' branch from CI/CD workflows

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -3,7 +3,6 @@ name: Build and push container images
 on:
   push:
     branches:
-      - "main"
       - "master"
     tags:
       - "olmap-backend-v*.*.*"

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -1,7 +1,6 @@
 on:
   push:
     branches:
-      - main
       - master
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [master, main, develop]
+    branches: [master, develop]
   pull_request:
-    branches: [master, main, develop]
+    branches: [master, develop]
 
 jobs:
   # Pre-commit hooks validation


### PR DESCRIPTION
## Summary
This PR removes the `main` branch from all CI/CD workflow triggers, consolidating the primary branch to `master` only.

## Changes
- **container-build.yml**: Removed `main` from push branches trigger
- **release-please.yaml**: Removed `main` from push branches trigger
- **test.yml**: Removed `main` from both push and pull_request branches triggers

## Details
The workflows now only trigger on the `master` branch (and `develop` for test.yml), eliminating duplicate CI/CD runs across multiple primary branches. This simplifies the branch strategy and ensures a single source of truth for production deployments and releases.

https://claude.ai/code/session_0149SVqQxNKWdibhh5huGb1s