### PR TITLE
fix(ci): repair pre-commit baseline (biome nested-root, yamllint, dup migrations key)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
     hooks:
       - id: biome-format
         name: biome format
-        entry: biome format --write --config-path react_ui
+        entry: biome format --write
         language: node
         additional_dependencies: ['@biomejs/biome@2.3.14']
         files: ^react_ui/.*\.(js|jsx|ts|tsx|json)$

--- a/.yamllint
+++ b/.yamllint
@@ -5,6 +5,11 @@ rules:
   line-length:
     max: 120
     level: warning
+  # Helm/k8s values align block sequences with their parent key; workflows
+  # indent them. Allow either, as long as each file is internally consistent.
+  indentation:
+    spaces: 2
+    indent-sequences: consistent
   document-start: disable  # Don't require --- at start
   truthy:
     allowed-values: ['true', 'false', 'on', 'off']

--- a/deploy/backend-values.yaml
+++ b/deploy/backend-values.yaml
@@ -5,12 +5,6 @@ image:
   repository: ghcr.io/forumviriumhelsinki/olmap-backend
   tag: "0.2.1"  # Updated by ArgoCD Image Updater
 
-# Migration job image - tracked separately for visibility
-migrations:
-  image:
-    repository: ghcr.io/forumviriumhelsinki/olmap-backend
-    tag: "0.2.1"  # Updated by ArgoCD Image Updater
-
 imagePullSecrets:
 - name: ghcr-login-secret
 
@@ -203,6 +197,10 @@ externalSecret:
 
 # Database migrations (Helm hook - runs before deployment)
 migrations:
+  # Migration job image - tracked separately for visibility (ArgoCD Image Updater)
+  image:
+    repository: ghcr.io/forumviriumhelsinki/olmap-backend
+    tag: "0.2.1"  # Updated by ArgoCD Image Updater
   enabled: true
   command: ['python']
   args: ['manage.py', 'migrate', '--noinput']

--- a/react_ui/biome.json
+++ b/react_ui/biome.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
+  "root": false,
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## What

Repairs the `Pre-commit Hooks & Code Quality` job, which fails on `master` and therefore on **every open PR** in this repo. Three independent root causes, all pre-existing baseline rot (not introduced by any specific PR):

| Hook | Root cause | Fix |
|---|---|---|
| `biome-format` | biome 2.x raised `nested root configuration` — `react_ui/biome.json` was treated as a root config while the hook ran from the repo root with `--config-path react_ui` | Mark it `"root": false` (nested/package config) + drop the redundant `--config-path` so biome auto-discovers per file; align `$schema` to the pinned `2.3.14` |
| `yamllint` | Helm/k8s values files align block sequences with their parent key; the default `indent-sequences: true` flagged every sequence | `indent-sequences: consistent` — workflows indent, values don't, both internally consistent |
| `check-yaml` | `deploy/backend-values.yaml` defined the top-level `migrations:` key **twice** (ruamel rejects dup keys) | Merge — see below |

## The duplicate-key bug (real, latent)

`deploy/backend-values.yaml` had two `migrations:` keys: one carrying `migrations.image` (for ArgoCD Image Updater tracking of the migration-job image) and a later one with the job spec but **no** `image`. YAML last-wins silently discarded the first, so the migration job never actually tracked its own image tag. Merged `image:` into the single `migrations:` block, preserving the `migrations.image.tag` path Image Updater writes to.

## Verification

```
pre-commit run check-yaml   --all-files   # Passed
pre-commit run yamllint     --all-files   # Passed
pre-commit run biome-format --all-files   # Passed
```

## Follow-up

Once this lands and master is green, the repo's stale Renovate PRs (currently `CONFLICTING`) should be closed and regenerated clean. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
