### PR TITLE
ci: migrate release-please to GitHub App token

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -13,8 +13,13 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.MY_RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Problem

The org PAT `MY_RELEASE_PLEASE_TOKEN` expired, failing release-please with `Bad credentials` on push to the default branch.

## Fix

Switch release-please auth to the GitHub App token (`CI_APP_ID` + `CI_APP_PRIVATE_KEY`), matching the `infrastructure` repo's working pattern. App tokens don't expire like the PAT.

Part of an org-wide PAT→App migration sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)